### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM mhart/alpine-node
-RUN apk add nodejs nodejs-npm
+FROM node:alpine
 RUN mkdir /peer-server
 WORKDIR /peer-server
 COPY package.json .
@@ -8,4 +7,5 @@ COPY lib ./lib
 COPY app.json .
 RUN npm install
 EXPOSE 9000
-CMD node bin/peerjs --port 9000
+ENTRYPOINT ["node", "bin/peerjs"]
+CMD [ "--port", "9000" ]


### PR DESCRIPTION
Use official node image, no need to apk install etc. which is dependent on keeping apk update up to date.